### PR TITLE
Rename the package to @concarne/react-scroll-fade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-scroll-fade",
+  "name": "@concarne/react-scroll-fade",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-scroll-fade",
+      "name": "@concarne/react-scroll-fade",
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-scroll-fade",
+  "name": "@concarne/react-scroll-fade",
   "version": "0.0.1",
   "description": "React component for scrolling to images with fade in and out",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
package is now live at https://www.npmjs.com/package/@concarne/react-scroll-fade